### PR TITLE
Added serial port CTS handling. (see HaliKey)

### DIFF
--- a/skeyer.py
+++ b/skeyer.py
@@ -5,10 +5,29 @@ import time
 import threading
 from keyboard._keyboard_event import KEY_DOWN, KEY_UP
 from math import trunc
+import serial
+
+"""
+Since this script has to run as root ('cuz Keyboard), you have to install
+the libraries using sudo:
+```
+sudo pip3 install pyserial
+sudo pip3 install keyboard
+sudo pip3 install pygame
+```
+This probably isn't required on Windows.
+"""
 keydown = 0
 dtime = 0
 utime = 0
 cwmsg = ""
+ser_try_again: float = 0.0
+
+# change to your serial port. On windows, this is something like 'COM5'  Set to None to disable serial port stuff.
+serial_port: str = "/dev/ttyUSB0"  
+ser: serial.Serial = None
+prev_cts: bool
+
 # Initialize Pygame
 pygame.mixer.init()
 
@@ -50,15 +69,27 @@ def key_release():
     utime = time.time()
     stop_sidetone()
 
-def on_action(event):
-    if event.name != "esc":
-        if event.event_type == KEY_DOWN:
-            key_press()
+def esc_pressed():
+    global cwmsg
+    global dtime
+    global utime
+    global keydown
+    print("found esc")
+    print(cwmsg)
+    msg_s = requests.get('http://192.168.4.1/light/skgo?msg='+cwmsg)
+    cwmsg = ""
+    dtime = 0
+    utime = 0
+    keydown = 0
+    print("cleared " + cwmsg)
 
-        elif event.event_type == KEY_UP:
-            key_release()
-    else:
-        print("found esc")
+def on_action(event):
+    if event.name == "esc":
+        esc_pressed()
+    elif event.event_type == KEY_DOWN:
+        key_press()
+    elif event.event_type == KEY_UP:
+        key_release()
 
 # Main function
 def main():
@@ -66,20 +97,43 @@ def main():
     global dtime
     global utime
     global keydown
+
     # Start listening for key events
+    # TODO from N6MTS: Look at keyboard.on_press_key and .on_release_key.
+    # You can map events directly to callbacks, without needing a 
+    # central on_action() director function.
     keyboard.hook(lambda e: on_action(e))
 
+    # Get the serial port immediately upon starting.
+    ser_try_again = time.time() - 1.0
+    ser = None
     try:
         while True:
-            # Block the main thread
-            keyboard.wait("esc")  # Wait until the "esc" key is pressed
-            print(cwmsg)
-            msg_s = requests.get('http://192.168.4.1/light/skgo?msg='+cwmsg)
-            cwmsg = ""
-            dtime = 0
-            utime = 0
-            keydown = 0
-            print("cleared " + cwmsg)
+            # Moved ESC processing to its own event handler.
+            # Serial is polling, so it has to stay in the event loop.
+            if serial_port is not None:
+                try:
+                    if ser is None and time.time() > ser_try_again:
+                        # Try opening the serial port
+                        ser = serial.Serial(serial_port)
+                        prev_cts = ser.cts
+                        print("Got serial")
+                    cts = ser.cts
+                except OSError:   # TODO this could be made more explicit.
+                    ser = None
+                    print("Couldn't get serial. Trying again in 3 seconds.")
+                    ser_try_again = time.time() + 3
+
+                if cts != prev_cts:
+                    #print(f"serial key: {cts}")
+                    if cts:
+                        key_press()
+                    else:
+                        key_release()
+                    prev_cts = cts
+
+            # Don't spin infinitely, just 1000 times a second.
+            time.sleep(0.001)
 
 
     except KeyboardInterrupt:


### PR DESCRIPTION
Sorry for just implementing the serial and not just letting you look at my code.  I got a little carried away this morning.  Thanks for the ADHD novelty brain chemistry hit.  :-)

Feel free to use, or not, this PR.  At the very least, the code in it shows you how to use the `pyserial` library to get at CTS, which is the Dit or Tip of HaliKey.  If you want it to also trigger on Dah/Ring, then add similar code for `serial.cd` or `serial.dsr`